### PR TITLE
DO NOT MERGE: Hack

### DIFF
--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -184,11 +184,40 @@ class AbsTask(ABC):
             )  ## only take the specified test split.
         return dataset_dict
 
-    def load_data(self, **kwargs):
+    def load_data_og(self, **kwargs):
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return
         self.dataset = datasets.load_dataset(**self.metadata_dict["dataset"])  # type: ignore
+        self.dataset_transform()
+        self.data_loaded = True
+
+    import os
+
+    # Wrapper for loading datasets
+    def load_dataset(*args, **kwargs) -> DatasetDict:
+        dataset_name = args[0].split("/")[-1]
+        print("Loading dataset", dataset_name)
+        if os.path.exists(
+                "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/" + dataset_name
+        ):
+            print(
+                "Loading dataset from local storage at /lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/"
+            )
+            return datasets.load_dataset(
+                "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/" + dataset_name,
+                *args[1:],
+                **kwargs,
+            )
+        else:
+            print("Loading dataset from Hugging Face")
+            return datasets.load_dataset(*args, **kwargs)
+
+    def load_data(self, **kwargs):
+        """Load dataset from HuggingFace hub"""
+        if self.data_loaded:
+            return
+        self.dataset = load_dataset(**self.metadata_dict["dataset"])  # type: ignore
         self.dataset_transform()
         self.data_loaded = True
 

--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -200,13 +200,13 @@ class AbsTask(ABC):
         dataset_name = kwargs.pop("path").split("/")[-1]
         print("Loading dataset", dataset_name)
         if os.path.exists(
-                "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/" + dataset_name
+                os.environ.get("LOCAL_DATASET_DIR", "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/") + dataset_name
         ):
             print(
-                "Loading dataset from local storage at /lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/"
+                "Loading dataset from local storage at"
             )
             return datasets.load_dataset(
-                "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/" + dataset_name,
+                os.environ.get("LOCAL_DATASET_DIR", "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/") + dataset_name,
                 **kwargs,
             )
         else:

--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -194,12 +194,10 @@ class AbsTask(ABC):
         self.data_loaded = True
 
     # Wrapper for loading datasets
-    def load_dataset(*args, **kwargs) -> DatasetDict:
-        print(f"Loading dataset with args: {args} and kwargs: {kwargs}")
-        try:
-            dataset_name = args[0].split("/")[-1]
-        except Exception:
-            dataset_name = kwargs.get("path").split("/")[-1]
+    @staticmethod
+    def load_dataset(**kwargs) -> DatasetDict:
+        print(f"Loading dataset with kwargs: {kwargs}")
+        dataset_name = kwargs.pop("path").split("/")[-1]
         print("Loading dataset", dataset_name)
         if os.path.exists(
                 "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/" + dataset_name
@@ -209,12 +207,11 @@ class AbsTask(ABC):
             )
             return datasets.load_dataset(
                 "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/" + dataset_name,
-                *args[1:],
                 **kwargs,
             )
         else:
             print("Loading dataset from Hugging Face")
-            return datasets.load_dataset(*args, **kwargs)
+            return datasets.load_dataset(**kwargs)
 
     def load_data(self, **kwargs):
         """Load dataset from HuggingFace hub"""

--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -199,14 +199,14 @@ class AbsTask(ABC):
         print(f"Loading dataset with kwargs: {kwargs}")
         dataset_name = kwargs.pop("path").split("/")[-1]
         print("Loading dataset", dataset_name)
-        if os.path.exists(
-                os.environ.get("LOCAL_DATASET_DIR", "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/") + dataset_name
-        ):
+        
+        if os.path.exists(os.environ["LOCAL_DATASET_DIR"] + "/" + dataset_name):
             print(
-                "Loading dataset from local storage at"
+                "Loading dataset from local storage at",
+                os.environ["LOCAL_DATASET_DIR"] + "/" + dataset_name
             )
             return datasets.load_dataset(
-                os.environ.get("LOCAL_DATASET_DIR", "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/") + dataset_name,
+                os.environ["LOCAL_DATASET_DIR"] + "/" + dataset_name,
                 **kwargs,
             )
         else:

--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import logging
 import random
 from abc import ABC, abstractmethod
@@ -192,8 +193,6 @@ class AbsTask(ABC):
         self.dataset_transform()
         self.data_loaded = True
 
-    import os
-
     # Wrapper for loading datasets
     def load_dataset(*args, **kwargs) -> DatasetDict:
         dataset_name = args[0].split("/")[-1]
@@ -217,7 +216,7 @@ class AbsTask(ABC):
         """Load dataset from HuggingFace hub"""
         if self.data_loaded:
             return
-        self.dataset = load_dataset(**self.metadata_dict["dataset"])  # type: ignore
+        self.dataset = self.load_dataset(**self.metadata_dict["dataset"])  # type: ignore
         self.dataset_transform()
         self.data_loaded = True
 

--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -195,7 +195,11 @@ class AbsTask(ABC):
 
     # Wrapper for loading datasets
     def load_dataset(*args, **kwargs) -> DatasetDict:
-        dataset_name = args[0].split("/")[-1]
+        print(f"Loading dataset with args: {args} and kwargs: {kwargs}")
+        try:
+            dataset_name = args[0].split("/")[-1]
+        except Exception:
+            dataset_name = kwargs.get("path").split("/")[-1]
         print("Loading dataset", dataset_name)
         if os.path.exists(
                 "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/" + dataset_name

--- a/mteb/tasks/Retrieval/fra/AlloprofRetrieval.py
+++ b/mteb/tasks/Retrieval/fra/AlloprofRetrieval.py
@@ -12,13 +12,13 @@ def load_dataset(**kwargs):
     dataset_name = kwargs.pop("path").split("/")[-1]
     print("Loading dataset", dataset_name)
     if os.path.exists(
-            "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/" + dataset_name
+            os.environ.get("LOCAL_DATASET_DIR", "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/") + dataset_name
     ):
         print(
-            "Loading dataset from local storage at /lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/"
+            "Loading dataset from local storage"
         )
         return datasets.load_dataset(
-            "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/" + dataset_name,
+            os.environ.get("LOCAL_DATASET_DIR", "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/") + dataset_name,
             **kwargs,
         )
     else:

--- a/mteb/tasks/Retrieval/fra/AlloprofRetrieval.py
+++ b/mteb/tasks/Retrieval/fra/AlloprofRetrieval.py
@@ -1,10 +1,29 @@
 from __future__ import annotations
-
+import os
 import datasets
 
 from mteb.abstasks.TaskMetadata import TaskMetadata
 
 from ....abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+def load_dataset(**kwargs):
+    print(f"Loading dataset with kwargs: {kwargs}")
+    dataset_name = kwargs.pop("path").split("/")[-1]
+    print("Loading dataset", dataset_name)
+    if os.path.exists(
+            "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/" + dataset_name
+    ):
+        print(
+            "Loading dataset from local storage at /lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/"
+        )
+        return datasets.load_dataset(
+            "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/" + dataset_name,
+            **kwargs,
+        )
+    else:
+        print("Loading dataset from Hugging Face")
+        return datasets.load_dataset(**kwargs)
 
 
 class AlloprofRetrieval(AbsTaskRetrieval):
@@ -58,11 +77,11 @@ class AlloprofRetrieval(AbsTaskRetrieval):
         if self.data_loaded:
             return
         # fetch both subsets of the dataset
-        corpus_raw = datasets.load_dataset(
+        corpus_raw = load_dataset(
             name="documents",
             **self.metadata_dict["dataset"],
         )
-        queries_raw = datasets.load_dataset(
+        queries_raw = load_dataset(
             name="queries",
             **self.metadata_dict["dataset"],
         )

--- a/mteb/tasks/Retrieval/fra/AlloprofRetrieval.py
+++ b/mteb/tasks/Retrieval/fra/AlloprofRetrieval.py
@@ -11,14 +11,13 @@ def load_dataset(**kwargs):
     print(f"Loading dataset with kwargs: {kwargs}")
     dataset_name = kwargs.pop("path").split("/")[-1]
     print("Loading dataset", dataset_name)
-    if os.path.exists(
-            os.environ.get("LOCAL_DATASET_DIR", "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/") + dataset_name
-    ):
+    if os.path.exists(os.environ["LOCAL_DATASET_DIR"] + "/" + dataset_name):
         print(
-            "Loading dataset from local storage"
+            "Loading dataset from local storage at", 
+            os.environ["LOCAL_DATASET_DIR"] + "/" + dataset_name,
         )
         return datasets.load_dataset(
-            os.environ.get("LOCAL_DATASET_DIR", "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/") + dataset_name,
+            os.environ["LOCAL_DATASET_DIR"] + "/" + dataset_name,
             **kwargs,
         )
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mteb"
-version = "1.14.26"
+version = "1.14.26-alpha"
 description = "Massive Text Embedding Benchmark"
 readme = "README.md"
 authors = [
@@ -56,8 +56,6 @@ dev = ["ruff==0.6.4", # locked so we don't get PRs which fail only due to a lint
 "pytest", "pytest-xdist", "pytest-coverage"]
 codecarbon = ["codecarbon"]
 speedtask = ["GPUtil>=1.4.0", "psutil>=5.9.8"]
-peft = ["peft>=0.11.0"]
-
 
 [tool.coverage.report]
 


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [ ] Run tests locally to make sure nothing is broken using `make test`. 
- [ ] Run the formatter to format the code using `make lint`. 


### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: ... <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [ ] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [ ] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [ ] `intfloat/multilingual-e5-small`
- [ ] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [ ] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [ ] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [ ] Run tests locally to make sure nothing is broken using `make test`. 
- [ ] Run the formatter to format the code using `make lint`. 


### Adding a model checklist
<!-- 
When adding a model to the model registry
see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md
-->

 - [ ] I have filled out the ModelMeta object to the extent possible
 - [ ] I have ensured that my model can be loaded using
   - [ ] `mteb.get_model(model_name, revision_id)` and
   - [ ] `mteb.get_model_meta(model_name, revision_id)`
 - [ ] I have tested the implementation works on a representative set of tasks.