### PR TITLE
modifs

### DIFF
--- a/mteb/abstasks/AbsTask.py
+++ b/mteb/abstasks/AbsTask.py
@@ -199,14 +199,14 @@ class AbsTask(ABC):
         print(f"Loading dataset with kwargs: {kwargs}")
         dataset_name = kwargs.pop("path").split("/")[-1]
         print("Loading dataset", dataset_name)
-        if os.path.exists(
-                os.environ.get("LOCAL_DATASET_DIR", "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/") + dataset_name
-        ):
+        
+        if os.path.exists(os.environ["LOCAL_DATASET_DIR"] + "/" + dataset_name):
             print(
-                "Loading dataset from local storage at"
+                "Loading dataset from local storage at",
+                os.environ["LOCAL_DATASET_DIR"] + "/" + dataset_name
             )
             return datasets.load_dataset(
-                os.environ.get("LOCAL_DATASET_DIR", "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/") + dataset_name,
+                os.environ["LOCAL_DATASET_DIR"] + "/" + dataset_name,
                 **kwargs,
             )
         else:

--- a/mteb/tasks/Retrieval/fra/AlloprofRetrieval.py
+++ b/mteb/tasks/Retrieval/fra/AlloprofRetrieval.py
@@ -11,14 +11,13 @@ def load_dataset(**kwargs):
     print(f"Loading dataset with kwargs: {kwargs}")
     dataset_name = kwargs.pop("path").split("/")[-1]
     print("Loading dataset", dataset_name)
-    if os.path.exists(
-            os.environ.get("LOCAL_DATASET_DIR", "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/") + dataset_name
-    ):
+    if os.path.exists(os.environ["LOCAL_DATASET_DIR"] + "/" + dataset_name):
         print(
-            "Loading dataset from local storage"
+            "Loading dataset from local storage at", 
+            os.environ["LOCAL_DATASET_DIR"] + "/" + dataset_name,
         )
         return datasets.load_dataset(
-            os.environ.get("LOCAL_DATASET_DIR", "/lus/scratch/CT6/c1615122/SHARED/data/eval_datasets_hf/") + dataset_name,
+            os.environ["LOCAL_DATASET_DIR"] + "/" + dataset_name,
             **kwargs,
         )
     else:


### PR DESCRIPTION
<!-- If you are submitting a dataset or a model for the model registry please use the corresponding checklists below otherwise feel free to remove them. -->

<!-- add additional description, question etc. related to the new dataset -->


## Checklist
<!-- Please do not delete this -->

- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 


### Adding datasets checklist
<!-- see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md -->

**Reason for dataset addition**: ... <!-- Add reason for adding dataset here. E.g. it covers task/language/domain previously not covered -->

- [x] I have run the following models on the task (adding the results to the pr). These can be run using the `mteb -m {model_name} -t {task_name}` command.
  - [x] `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`
  - [x] `intfloat/multilingual-e5-small`
- [x] I have checked that the performance is neither trivial (both models gain close to perfect scores) nor random (both models gain close to random scores).
- [x] If the dataset is too big (e.g. >2048 examples), considering using `self.stratified_subsampling() under dataset_transform()`
- [x] I have filled out the metadata object in the dataset file (find documentation on it [here](https://github.com/embeddings-benchmark/mteb/blob/main/docs/adding_a_dataset.md#2-creating-the-metadata-object)).
- [x] Run tests locally to make sure nothing is broken using `make test`. 
- [x] Run the formatter to format the code using `make lint`. 


### Adding a model checklist
<!-- 
When adding a model to the model registry
see also https://github.com/embeddings-benchmark/mteb/blob/main/docs/reproducible_workflow.md
-->

 - [x] I have filled out the ModelMeta object to the extent possible
 - [x] I have ensured that my model can be loaded using
   - [x] `mteb.get_model(model_name, revision_id)` and
   - [x] `mteb.get_model_meta(model_name, revision_id)`
 - [x] I have tested the implementation works on a representative set of tasks.